### PR TITLE
Only allow regular messages

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -412,6 +412,7 @@ class Shard extends EventEmitter {
             case "MESSAGE_CREATE": {
                 const channel = this.client.getChannel(packet.d.channel_id);
                 if(channel) { // MESSAGE_CREATE just when deleting o.o
+                    if (packet.d.type != 0) return; // https://discordapp.com/developers/docs/resources/channel#message-object-message-types
                     channel.lastMessageID = packet.d.id;
                     /**
                     * Fired when a message is created


### PR DESCRIPTION
This should only allow regular messages to go through to the bot, and none others (welcome messages, new pinned message, etc.).

The nitro boosts have been causing the `Unhandled MESSAGE_CREATE` errors. Hopefully, this fixes it.

This may error/not work at all so first we'd have to test on a test bot.